### PR TITLE
Add support for overriding uid/gid via Docker ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:latest
 LABEL version="1.0" maintainer="John Stucklen <stuckj@gmail.com>"
 
+ENV SUBSONIC_UID 1000
+ENV SUBSONIC_GID 1000
+
 RUN apt update \
   && apt upgrade -y \
   && apt install -y locales ffmpeg openjdk-8-jre-headless nano flac lame mikmod timidity wget \
@@ -24,9 +27,6 @@ COPY mikmod_stdout /opt/subsonic
 COPY timidity_stdout /opt/subsonic
 
 COPY entrypoint.sh /opt/subsonic/entrypoint.sh
-
-RUN groupadd --system --gid 1000 subsonic \
-  && useradd --system --home-dir /var/subsonic --shell /usr/sbin/nologin --gid 1000 --uid 1000 subsonic
 
 WORKDIR /opt/subsonic
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ variables. See the table below for customization options.
 | SUBSONIC_DEFAULT_MUSIC_FOLDER    | The default folder (within the container) for music.                                                      | /var/music         |
 | SUBSONIC_DEFAULT_PODCAST_FOLDER  | The default folder (within the container) for podcasts.                                                   | /var/music/Podcast |
 | SUBSONIC_DEFAULT_PLAYLIST_FOLDER | The default folder (within the container) for playlists.                                                  | /var/playlists     |
+| SUBSONIC_UID                     | The numeric user id to use for the subsonic user                                                          | 1000               |
+| SUBSONIC_GID                     | The numeric group id to use for the subsonic user group                                                   | 1000               |
 
 ## Tracker (MOD, S3M, etc) / MIDI support
 
@@ -45,8 +47,8 @@ The container will use volumes for for the following directories within the cont
 
 ## Permissions
 
-Subsonic will be run by a service user inside the container (subsonic) with UID=1000 and GID=1000. The
-UID / GID are not currently customizable without modifying the Dockerfile. The permissions will be set
+Subsonic will be run by a service user inside the container (subsonic) with the UID / GID configured via
+the `SUBSONIC_UID`/`SUBSONIC_GID` environment variables (Default `1000`/`1000`). The permissions will be set
 on any directory / volume you map onto `/var/subsonic` so that it is owned by subsonic:subsonic. If you
 are transferring a subsonic installation to this container make sure to change ownership of everything
 under `/var/subsonic` to subsonic:subsonic. You can do this with this command: `chmod -R subsonic:subsonic DIR`
@@ -74,6 +76,8 @@ docker run -it \
     -p "8080:8080/tcp" \
     -eSUBSONIC_PORT=8080 \
     -eSUBSONIC_MAX_MEMORY=512 \
+    -eSUBSONIC_UID=33 \
+    -eSUBSONIC_GID=33 \
     -v /data/music:/var/music \
     -v /data/playlists:/var/playlists \
     -v /data/subsonic-data:/var/subsonic \
@@ -94,6 +98,8 @@ services:
     environment:
       - SUBSONIC_MAX_MEMORY=512
       - SUBSONIC_PORT=8080
+      - SUBSONIC_UID=33
+      - SUBSONIC_GID=33
     ports:
       - 8080:8080/tcp
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,9 +19,13 @@ SUBSONIC_DEFAULT_PODCAST_FOLDER=${SUBSONIC_DEFAULT_PODCAST_FOLDER:-/var/music/Po
 SUBSONIC_DEFAULT_PLAYLIST_FOLDER=${SUBSONIC_DEFAULT_PLAYLIST_FOLDER:-/var/playlists}
 
 # Create subsonic user, taking uid, gid and homedir from (Docker) environment
-groupadd --system -o --gid "$SUBSONIC_GID" subsonic && \
+if ! id -g subsonic > /dev/null 2>&1; then
+    groupadd --system -o --gid "$SUBSONIC_GID" subsonic
+fi
+if ! id -u subsonic > /dev/null 2>&1; then
     useradd --system -o --home-dir "$SUBSONIC_HOME" --shell /usr/sbin/nologin \
             --gid "$SUBSONIC_GID" --uid "$SUBSONIC_UID" subsonic
+fi
 
 # Use JAVA_HOME if set, otherwise assume java is in the path.
 JAVA=java

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,9 +19,9 @@ SUBSONIC_DEFAULT_PODCAST_FOLDER=${SUBSONIC_DEFAULT_PODCAST_FOLDER:-/var/music/Po
 SUBSONIC_DEFAULT_PLAYLIST_FOLDER=${SUBSONIC_DEFAULT_PLAYLIST_FOLDER:-/var/playlists}
 
 # Create subsonic user, taking uid, gid and homedir from (Docker) environment
-groupadd --system -o --gid "$SUBSONIC_UID" subsonic && \
+groupadd --system -o --gid "$SUBSONIC_GID" subsonic && \
     useradd --system -o --home-dir "$SUBSONIC_HOME" --shell /usr/sbin/nologin \
-            --gid "$SUBSONIC_UID" --uid "$SUBSONIC_GID" subsonic
+            --gid "$SUBSONIC_GID" --uid "$SUBSONIC_UID" subsonic
 
 # Use JAVA_HOME if set, otherwise assume java is in the path.
 JAVA=java

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,11 @@ SUBSONIC_DEFAULT_MUSIC_FOLDER=${SUBSONIC_DEFAULT_MUSIC_FOLDER:-/var/music}
 SUBSONIC_DEFAULT_PODCAST_FOLDER=${SUBSONIC_DEFAULT_PODCAST_FOLDER:-/var/music/Podcast}
 SUBSONIC_DEFAULT_PLAYLIST_FOLDER=${SUBSONIC_DEFAULT_PLAYLIST_FOLDER:-/var/playlists}
 
+# Create subsonic user, taking uid, gid and homedir from (Docker) environment
+groupadd --system -o --gid "$SUBSONIC_UID" subsonic && \
+    useradd --system -o --home-dir "$SUBSONIC_HOME" --shell /usr/sbin/nologin \
+            --gid "$SUBSONIC_UID" --uid "$SUBSONIC_GID" subsonic
+
 # Use JAVA_HOME if set, otherwise assume java is in the path.
 JAVA=java
 if [ -e "${JAVA_HOME}" ]; then


### PR DESCRIPTION
Hello @stuckj!

First up, thank you for creating this docker image.
I was looking into creating a more up to date subsonic docker image - currently I'm stuck with version 5 from an image, that's decent but hasn't been updated for years.
Also, I want it to be available on Docker Hub, but I didn't want to add yet another (probably half-baked) image.
So, I looked through the most recently updated images and found yours, which was among the few that had a decent README and a link to the repo ;-), so I thought it might make sense to build up on this one.

The image works fine for me except for one thing: I need to be able to adjust the UID/GID of the subsonic user.
So, I've added that capability in this feature branch (for details please see commit message below).

It would be great if you could consider to merge this into main, so others can benefit from it as well - and I could just use the mainline image without the need to build my own.

Apart from this, I'd also have some suggestions for improving the image.
So, if you're interested, I'd be happy to create some more pull requests with those changes.

Looking forward to hearing from you!

Cheers,
@2-Shell

-----

Currently overriding the UID/GID that the subsonic process will run from the docker environment is not possible.
This creates problems when the the dir containing the music library cannot be chowned for some reason (e.g. other processes requiring access as well).

To remove this limitation, this commit introduces Docker environment variables `SUBSONIC_UID` and `SUBSONIC_GID` and moves the actual user/group creation into the entrypoint script, using the environment variables instead of hard coded values.
This is possible, because the presence of the user is not strictly required for the operations in the Dockerfile.

The default values for `SUBSONIC_UID` and `SUBSONIC_GID` are set to 1000, so the overall default behavior shouldn't change.

Instead, this even fixes the issue, where the subsonic user's hardcoded homedir might diverge from the process' homedir set via the `SUBSONIC_HOME` environment variable.