### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV LANGUAGE en_US:en
 ENV SUBSONIC_UID 1000
 ENV SUBSONIC_GID 1000
 
-RUN apt-get update \
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y locales ffmpeg openjdk-8-jre-headless nano flac lame mikmod timidity wget \
   && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,14 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    locale-gen && \
-    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+  && locale-gen \
+  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-RUN mkdir -p /opt/subsonic && \
-    wget --no-check-certificate https://s3-eu-west-1.amazonaws.com/subsonic-public/download/subsonic-6.1.6-standalone.tar.gz && \
-    tar xvzf subsonic-6.1.6-standalone.tar.gz -C /opt/subsonic && \
-    rm -rf subsonic-6.1.6-standalone.tar.gz
+RUN mkdir -p /opt/subsonic \
+  && wget --no-check-certificate https://s3-eu-west-1.amazonaws.com/subsonic-public/download/subsonic-6.1.6-standalone.tar.gz \
+  && tar xvzf subsonic-6.1.6-standalone.tar.gz -C /opt/subsonic \
+  && rm -rf subsonic-6.1.6-standalone.tar.gz
 
 COPY mikmod_stdout /opt/subsonic
 COPY timidity_stdout /opt/subsonic

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:latest
-LABEL version="1.0" maintainer="John Stucklen <stuckj@gmail.com>"
+LABEL version="1.1" maintainer="John Stucklen <stuckj@gmail.com>"
 
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 ENV SUBSONIC_UID 1000
 ENV SUBSONIC_GID 1000
 
@@ -11,21 +14,16 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    locale-gen
-ENV LC_ALL en_US.UTF-8 
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en 
+    locale-gen && \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-RUN mkdir -p /opt/subsonic \
-  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-
-RUN wget --no-check-certificate https://s3-eu-west-1.amazonaws.com/subsonic-public/download/subsonic-6.1.6-standalone.tar.gz \
-  && tar xvzf subsonic-6.1.6-standalone.tar.gz -C /opt/subsonic \
-  && rm -rf subsonic-6.1.6-standalone.tar.gz
+RUN mkdir -p /opt/subsonic && \
+    wget --no-check-certificate https://s3-eu-west-1.amazonaws.com/subsonic-public/download/subsonic-6.1.6-standalone.tar.gz && \
+    tar xvzf subsonic-6.1.6-standalone.tar.gz -C /opt/subsonic && \
+    rm -rf subsonic-6.1.6-standalone.tar.gz
 
 COPY mikmod_stdout /opt/subsonic
 COPY timidity_stdout /opt/subsonic
-
 COPY entrypoint.sh /opt/subsonic/entrypoint.sh
 
 WORKDIR /opt/subsonic

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ ENV LANGUAGE en_US:en
 ENV SUBSONIC_UID 1000
 ENV SUBSONIC_GID 1000
 
-RUN apt update \
-  && apt upgrade -y \
-  && apt install -y locales ffmpeg openjdk-8-jre-headless nano flac lame mikmod timidity wget \
-  && apt clean \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y locales ffmpeg openjdk-8-jre-headless nano flac lame mikmod timidity wget \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \


### PR DESCRIPTION
Hi @stuckj,

This is a first batch of smaller improvements in the Dockerfile only:
- regrouped and re-ordered the commands in the Dockerfile a bit, so they form logical units (some more) and conform to best practices (env definitions grouped, at the top).
- replaced `apt` (which is intended for interactive use) with `apt-get` (which is more suitable for being used in scripts)
- set `noninteractive` to avoid any (future) package installation failures from packages requesting user input

I have another batch lined up, but implementing those depends on whether you agree with these changes, or not.
So I'm pushing these first.