### PR TITLE
Env var improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
 FROM ubuntu:latest
-LABEL version="1.1" maintainer="John Stucklen <stuckj@gmail.com>"
+LABEL version="1.2" maintainer="John Stucklen <stuckj@gmail.com>"
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
+ENV SUBSONIC_HOME /var/subsonic
+ENV SUBSONIC_HOST 0.0.0.0
+ENV SUBSONIC_PORT 4040
+ENV SUBSONIC_HTTPS_PORT 0
+ENV SUBSONIC_CONTEXT_PATH /
+ENV SUBSONIC_DB ""
+ENV SUBSONIC_MAX_MEMORY 150
+ENV SUBSONIC_DEFAULT_MUSIC_FOLDER /var/music
+ENV SUBSONIC_DEFAULT_PODCAST_FOLDER /var/music/Podcast
+ENV SUBSONIC_DEFAULT_PLAYLIST_FOLDER /var/playlists
 ENV SUBSONIC_UID 1000
 ENV SUBSONIC_GID 1000
 
@@ -29,8 +39,8 @@ COPY entrypoint.sh /opt/subsonic/entrypoint.sh
 
 WORKDIR /opt/subsonic
 
-VOLUME [ "/var/music", "/var/playlists", "/var/subsonic" ]
+VOLUME $SUBSONIC_DEFAULT_MUSIC_FOLDER $SUBSONIC_DEFAULT_PLAYLIST_FOLDER $SUBSONIC_HOME
 
-EXPOSE 4040/tcp
+EXPOSE $SUBSONIC_PORT/tcp
 
 ENTRYPOINT [ "/opt/subsonic/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,19 +5,6 @@ set -e
 # This is a replacement for subsonic.sh that comes with subsonic as it is not docker friendly
 # This will properly NOT daemonize the java process and will log to stdout / stderr.
 
-# Note: default to environment variables, if set.
-
-SUBSONIC_HOME=${SUBSONIC_HOME:-/var/subsonic}
-SUBSONIC_HOST=${SUBSONIC_HOST:-0.0.0.0}
-SUBSONIC_PORT=${SUBSONIC_PORT:-4040}
-SUBSONIC_HTTPS_PORT=${SUBSONIC_HTTPS_PORT:-0}
-SUBSONIC_CONTEXT_PATH=${SUBSONIC_CONTEXT_PATH:-/}
-SUBSONIC_DB=${SUBSONIC_DB}
-SUBSONIC_MAX_MEMORY=${SUBSONIC_MAX_MEMORY:-150}
-SUBSONIC_DEFAULT_MUSIC_FOLDER=${SUBSONIC_DEFAULT_MUSIC_FOLDER:-/var/music}
-SUBSONIC_DEFAULT_PODCAST_FOLDER=${SUBSONIC_DEFAULT_PODCAST_FOLDER:-/var/music/Podcast}
-SUBSONIC_DEFAULT_PLAYLIST_FOLDER=${SUBSONIC_DEFAULT_PLAYLIST_FOLDER:-/var/playlists}
-
 # Create subsonic user, taking uid, gid and homedir from (Docker) environment
 if ! id -g subsonic > /dev/null 2>&1; then
     groupadd --system -o --gid "$SUBSONIC_GID" subsonic

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ exec /bin/su -s /bin/bash -c "${JAVA} -Xmx${SUBSONIC_MAX_MEMORY}m \
   -Dsubsonic.port=${SUBSONIC_PORT} \
   -Dsubsonic.httpsPort=${SUBSONIC_HTTPS_PORT} \
   -Dsubsonic.contextPath=${SUBSONIC_CONTEXT_PATH} \
-  -Dsubsonic.db="${SUBSONIC_DB}" \
+  -Dsubsonic.db=\"${SUBSONIC_DB}\" \
   -Dsubsonic.defaultMusicFolder=${SUBSONIC_DEFAULT_MUSIC_FOLDER} \
   -Dsubsonic.defaultPodcastFolder=${SUBSONIC_DEFAULT_PODCAST_FOLDER} \
   -Dsubsonic.defaultPlaylistFolder=${SUBSONIC_DEFAULT_PLAYLIST_FOLDER} \


### PR DESCRIPTION
Moving the env var definitions into the Dockerfile would make it IMHO clearer that these variables are in fact part of the image's "API".

This also enables discovering the vars with `docker inspect`, without looking inside the image and find its entrypoint script.

Another side effect is, that we can avoid code duplication of default values (e.g. port).
This is currently not a big deal, but could help with future additions.

This is of course subjective and I totally understand if you would rather keep things like they are, so this is just a suggestion.