### PR TITLE
Add build args to control the subsonic version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM ubuntu:latest
 LABEL version="1.1" maintainer="John Stucklen <stuckj@gmail.com>"
 
+ARG DL_BASE_URL=https://s3-eu-west-1.amazonaws.com/subsonic-public/download
+ARG DL_VERSION=6.1.6
+ARG DL_SHA256=dfb78fa9bb38f2265f498122846b1d6121f7666035a78dbe3a24305bd16c18a0
+
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV SUBSONIC_UID 1000
 ENV SUBSONIC_GID 1000
+ENV SUBSONIC_VERSION $DL_VERSION
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
@@ -19,9 +24,10 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 RUN mkdir -p /opt/subsonic \
-  && wget --no-check-certificate https://s3-eu-west-1.amazonaws.com/subsonic-public/download/subsonic-6.1.6-standalone.tar.gz \
-  && tar xvzf subsonic-6.1.6-standalone.tar.gz -C /opt/subsonic \
-  && rm -rf subsonic-6.1.6-standalone.tar.gz
+  && wget --no-check-certificate $DL_BASE_URL/subsonic-$DL_VERSION-standalone.tar.gz \
+  && echo $DL_SHA256 *subsonic-$DL_VERSION-standalone.tar.gz | sha256sum -c - \
+  && tar xvzf subsonic-$DL_VERSION-standalone.tar.gz -C /opt/subsonic \
+  && rm -rf subsonic-$DL_VERSION-standalone.tar.gz
 
 COPY mikmod_stdout /opt/subsonic
 COPY timidity_stdout /opt/subsonic


### PR DESCRIPTION
This PR adds docker build args for controlling the Subsonic binary download and refactors the download logic, such that docker images for multiple specific Subsonic versions can be built more easily.

Also, this adds a safety check on the downloaded binary, by comparing the SHA-256 of the downloaded archive against the specified value.

These args can be used to build multiple images with different subsonic versions like so:

```bash
docker build -t subsonic-docker:6.1.5 \
    --build-arg DL_VERSION=6.1.5 \
    --build-arg DL_SHA256=662463f291c747cbea7e7a8b34f3fd65f19ecbbefdff18dedeacc3d23a75e3f7 .

docker build -t subsonic-docker:6.1.4 \
    --build-arg DL_VERSION=6.1.4 \
    --build-arg DL_SHA256=2b1998982d8424f115841aa30ab85f9d35a18f9dc38ac62d50f5834a17293a6e .
```

Available versions and SHA-256 values can be taken from the official [Subsonic download page](http://www.subsonic.org/pages/download.jsp).

This does intentionally _not_ implement automatic installation of the latest released binary.  
The rationale is, that even for older subsonic versions it must be possible to build updated images (e.g. for receiving distribution package updates, fixing bugs, etc.). 

Therefore, this PR provides the foundation for building the image for any Subsonic version from a simple CI script as shown above.

If desired, the [file containing all official checksums](https://s3-eu-west-1.amazonaws.com/subsonic-public/download/checksums-sha256.txt) could be used to build images for all versions with some bash-acrobatics like this:

```bash
curl -s https://s3-eu-west-1.amazonaws.com/subsonic-public/download/checksums-sha256.txt \
  | grep standalone \
  | while read pair; do 
      version=$(echo "$pair" | sed -e 's:.*subsonic-\([^-]*\).*:\1:')
      sha256=$(echo "$pair" | sed -e 's: .*::')
      docker build -t subsonic-docker:"$version" \
        --build-arg DL_VERSION="$version" \
        --build-arg DL_SHA256="$sha256" \
        .
  done
```

... or for building just the latest version with something like this:

```bash
version=$(curl -s https://s3-eu-west-1.amazonaws.com/subsonic-public/download/checksums-sha256.txt \
                  | grep standalone \
                  | cut -f 3 -d ' ' | sort | tail -1 \
                  | sed -e 's:subsonic-\([^-]*\)-.*:\1:')
sha256=$(curl -s https://s3-eu-west-1.amazonaws.com/subsonic-public/download/checksums-sha256.txt \
                   | grep standalone | grep "$version" | cut -f 1 -d ' ')

docker build -t subsonic-docker:"$version" \
  --build-arg DL_VERSION="$version" \
  --build-arg DL_SHA256="$sha256" \
  .
```
However, since releases (as you have already said) are infrequent and to avoid instabilities due to changing contents of the checksum file, I'd recommend just setting up a simple CI job with hardcoded values for known and supported versions.

Not knowing anything about you CI infrastructure, an example job for e.g. Gitlab CI could look something like this:
```yaml
---
# Example .gitlab-ci.yaml for building and publishing multiple image versions
build:docker:
  stage: build
  image: docker:latest
  services:
    - docker:dind
  variables:
    DOCKER_DRIVER: overlay2
    IMAGE_URL: subsonic-docker
  before_script:
    - apk add bash curl
  script:
    - >-
      docker build -t "$IMAGE_URL:$BUILD_VERSION"
      --build-arg DL_VERSION="$BUILD_VERSION"
      --build-arg DL_SHA256="$BUILD_SHA256"
      .
    - docker push "$IMAGE_URL:$BUILD_VERSION"
  parallel:
    matrix:
      - BUILD_VERSION: 6.1.6
        BUILD_SHA256: dfb78fa9bb38f2265f498122846b1d6121f7666035a78dbe3a24305bd16c18a0
      - BUILD_VERSION: 6.1.5
        BUILD_SHA256: 662463f291c747cbea7e7a8b34f3fd65f19ecbbefdff18dedeacc3d23a75e3f7
...
```

Please let me know what you think about these changes.